### PR TITLE
reconnect: add GDestroyNotify callback

### DIFF
--- a/plugins/relay/src/server.c
+++ b/plugins/relay/src/server.c
@@ -209,7 +209,7 @@ eventd_relay_server_new(void)
     server = g_new0(EventdRelayServer, 1);
 
     server->evp = libeventd_evp_context_new(server, &_eventd_relay_interface);
-    server->reconnect = libeventd_reconnect_new(5, 10,_eventd_relay_reconnect_callback, server);
+    server->reconnect = libeventd_reconnect_new(5, 10,_eventd_relay_reconnect_callback, server, g_free);
     server->events = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, _eventd_relay_event_free);
 
     return server;

--- a/server/libeventd/include/libeventd-reconnect.h
+++ b/server/libeventd/include/libeventd-reconnect.h
@@ -27,7 +27,7 @@ typedef struct _LibeventdReconnectHandler LibeventdReconnectHandler;
 
 typedef void (*LibeventdReconnectTryCallback)(LibeventdReconnectHandler *handler, gpointer user_data);
 
-LibeventdReconnectHandler *libeventd_reconnect_new(gint64 timeout, gint64 max_tries, LibeventdReconnectTryCallback callback, gpointer user_data);
+LibeventdReconnectHandler *libeventd_reconnect_new(gint64 timeout, gint64 max_tries, LibeventdReconnectTryCallback callback, gpointer user_data, GDestroyNotify notify);
 void libeventd_reconnect_free(LibeventdReconnectHandler *handler);
 
 gboolean libeventd_reconnect_try(LibeventdReconnectHandler *handler);


### PR DESCRIPTION
The `user_data` object can be allocated any way by the caller. Use
`GDestroyNotify` to free the data.

Signed-off-by: Ben Boeckel <mathstuf@gmail.com>