### PR TITLE
libeventd: rename configuration types

### DIFF
--- a/plugins/canberra/src/canberra.c
+++ b/plugins/canberra/src/canberra.c
@@ -40,8 +40,8 @@ struct _EventdPluginContext {
 };
 
 typedef struct {
-    FormatString *sound_name;
-    Filename *sound_file;
+    LibeventdFormatString *sound_name;
+    LibeventdFilename *sound_file;
 } EventdCanberraEvent;
 
 
@@ -50,7 +50,7 @@ typedef struct {
  */
 
 static EventdCanberraEvent *
-_eventd_canberra_event_new(FormatString *sound_name, Filename *sound_file)
+_eventd_canberra_event_new(LibeventdFormatString *sound_name, LibeventdFilename *sound_file)
 {
     EventdCanberraEvent *event;
 
@@ -164,8 +164,8 @@ _eventd_libcanberra_event_parse(EventdPluginContext *context, const gchar *id, G
 {
     gboolean disable;
     EventdCanberraEvent *canberra_event = NULL;
-    FormatString *sound_name = NULL;
-    Filename *sound_file = NULL;
+    LibeventdFormatString *sound_name = NULL;
+    LibeventdFilename *sound_file = NULL;
 
     if ( ! g_key_file_has_group(config_file, "Libcanberra") )
         return;

--- a/plugins/exec/src/exec.c
+++ b/plugins/exec/src/exec.c
@@ -67,7 +67,7 @@ static void
 _eventd_exec_event_parse(EventdPluginContext *context, const gchar *config_id, GKeyFile *config_file)
 {
     gboolean disable;
-    FormatString *command = NULL;
+    LibeventdFormatString *command = NULL;
 
     if ( ! g_key_file_has_group(config_file, "Exec") )
         return;
@@ -98,7 +98,7 @@ _eventd_exec_config_reset(EventdPluginContext *context)
 static void
 _eventd_exec_event_action(EventdPluginContext *context, const gchar *config_id, EventdEvent *event)
 {
-    const FormatString *command;
+    const LibeventdFormatString *command;
     gchar *cmd;
     GError *error;
 

--- a/plugins/im/src/im.c
+++ b/plugins/im/src/im.c
@@ -59,7 +59,7 @@ typedef struct {
 
 typedef struct {
     EventdImAccount *account;
-    FormatString *message;
+    LibeventdFormatString *message;
     GList *convs;
 } EventdImEventAccount;
 
@@ -336,7 +336,7 @@ _eventd_im_global_parse(EventdPluginContext *context, GKeyFile *config_file)
         gchar *protocol = NULL;
         gchar *username = NULL;
         gchar *password = NULL;
-        Int port;
+        LibeventdInt port;
         gint64 reconnect_timeout;
         gint64 reconnect_max_tries;
         gint64 leave_timeout;
@@ -435,7 +435,7 @@ _eventd_im_event_parse(EventdPluginContext *context, const gchar *config_id, GKe
 
         have_account = TRUE;
 
-        FormatString *message = NULL;
+        LibeventdFormatString *message = NULL;
         if ( libeventd_config_key_file_get_locale_format_string(config_file, section, "Message", NULL, &message) != 0 )
             goto next;
 

--- a/plugins/nd/src/cairo.c
+++ b/plugins/nd/src/cairo.c
@@ -219,7 +219,7 @@ _eventd_nd_cairo_text_process(EventdNdNotificationContents *notification, Eventd
 }
 
 static void
-_eventd_nd_cairo_bubble_draw(cairo_t *cr, Colour colour, gint radius, gint width, gint height)
+_eventd_nd_cairo_bubble_draw(cairo_t *cr, LibeventdColour colour, gint radius, gint width, gint height)
 {
     cairo_set_source_rgba(cr, colour.r, colour.g, colour.b, colour.a);
 
@@ -273,7 +273,7 @@ _eventd_nd_cairo_text_draw(cairo_t *cr, EventdNdStyle *style, PangoLayout *title
         offset_y += ( max_height - title_height ) / 2;
     pango_layout_set_width(title, max_width * PANGO_SCALE);
 
-    Colour colour;
+    LibeventdColour colour;
 
     colour = eventd_nd_style_get_title_colour(style);
     cairo_set_source_rgba(cr, colour.r, colour.g, colour.b, colour.a);

--- a/plugins/nd/src/nd.c
+++ b/plugins/nd/src/nd.c
@@ -329,7 +329,7 @@ _eventd_nd_global_parse(EventdPluginContext *context, GKeyFile *config_file)
 {
     if ( g_key_file_has_group(config_file, "Notification") )
     {
-        Int integer;
+        LibeventdInt integer;
         guint64 enum_value;
         gboolean boolean;
 

--- a/plugins/nd/src/style.c
+++ b/plugins/nd/src/style.c
@@ -66,11 +66,11 @@ struct _EventdNdStyle {
     struct {
         gboolean set;
 
-        FormatString *title;
-        FormatString *message;
+        LibeventdFormatString *title;
+        LibeventdFormatString *message;
 #ifdef ENABLE_GDK_PIXBUF
-        Filename *image;
-        Filename *icon;
+        LibeventdFilename *image;
+        LibeventdFilename *icon;
 #endif /* ENABLE_GDK_PIXBUF */
     } template;
 
@@ -82,7 +82,7 @@ struct _EventdNdStyle {
 
         gint   padding;
         gint   radius;
-        Colour colour;
+        LibeventdColour colour;
     } bubble;
 
 #ifdef ENABLE_GDK_PIXBUF
@@ -111,7 +111,7 @@ struct _EventdNdStyle {
 
         PangoFontDescription *font;
         PangoAlignment align;
-        Colour colour;
+        LibeventdColour colour;
     } title;
 
     struct {
@@ -121,7 +121,7 @@ struct _EventdNdStyle {
         guint8 max_lines;
         PangoFontDescription *font;
         PangoAlignment align;
-        Colour colour;
+        LibeventdColour colour;
     } message;
 };
 
@@ -221,7 +221,7 @@ eventd_nd_style_update(EventdNdStyle *self, GKeyFile *config_file, gint *images_
     {
         self->template.set = TRUE;
 
-        FormatString *string = NULL;
+        LibeventdFormatString *string = NULL;
 
         libeventd_format_string_unref(self->template.title);
         if ( libeventd_config_key_file_get_locale_format_string(config_file, "Notification", "Title", NULL, &string) == 0 )
@@ -237,7 +237,7 @@ eventd_nd_style_update(EventdNdStyle *self, GKeyFile *config_file, gint *images_
             self->template.message = libeventd_format_string_ref(eventd_nd_style_get_template_message(self->parent));
 
 #ifdef ENABLE_GDK_PIXBUF
-        Filename *filename = NULL;
+        LibeventdFilename *filename = NULL;
 
         libeventd_filename_unref(self->template.image);
         if ( libeventd_config_key_file_get_filename(config_file, "Notification", "Image", &filename) == 0 )
@@ -258,8 +258,8 @@ eventd_nd_style_update(EventdNdStyle *self, GKeyFile *config_file, gint *images_
     {
         self->bubble.set = TRUE;
 
-        Int integer;
-        Colour colour;
+        LibeventdInt integer;
+        LibeventdColour colour;
 
         if ( libeventd_config_key_file_get_int(config_file, "NotificationBubble", "MinWidth", &integer) == 0 )
             self->bubble.min_width = ( integer.value > 0 ) ? integer.value : 0;
@@ -297,7 +297,7 @@ eventd_nd_style_update(EventdNdStyle *self, GKeyFile *config_file, gint *images_
 
         gchar *string;
         guint64 enum_value;
-        Colour colour;
+        LibeventdColour colour;
 
         if ( libeventd_config_key_file_get_string(config_file, "NotificationTitle", "Font", &string) == 0 )
         {
@@ -326,10 +326,10 @@ eventd_nd_style_update(EventdNdStyle *self, GKeyFile *config_file, gint *images_
     {
         self->message.set = TRUE;
 
-        Int integer;
+        LibeventdInt integer;
         gchar *string;
         guint64 enum_value;
-        Colour colour;
+        LibeventdColour colour;
 
         if ( libeventd_config_key_file_get_int(config_file, "NotificationMessage", "Spacing", &integer) == 0 )
             self->message.spacing = integer.value;
@@ -369,7 +369,7 @@ eventd_nd_style_update(EventdNdStyle *self, GKeyFile *config_file, gint *images_
     {
         self->image.set = TRUE;
 
-        Int integer;
+        LibeventdInt integer;
 
         if ( libeventd_config_key_file_get_int(config_file, "NotificationImage", "MaxWidth", &integer) == 0 )
         {
@@ -399,7 +399,7 @@ eventd_nd_style_update(EventdNdStyle *self, GKeyFile *config_file, gint *images_
         self->icon.set = TRUE;
 
         guint64 enum_value;
-        Int integer;
+        LibeventdInt integer;
 
         if ( libeventd_config_key_file_get_enum(config_file, "NotificationIcon", "Placement", _eventd_nd_style_icon_placements, G_N_ELEMENTS(_eventd_nd_style_icon_placements), &enum_value) == 0 )
             self->icon.placement = enum_value;
@@ -466,7 +466,7 @@ eventd_nd_style_free(gpointer data)
 }
 
 
-FormatString *
+LibeventdFormatString *
 eventd_nd_style_get_template_title(EventdNdStyle *self)
 {
     if ( self->template.set )
@@ -474,7 +474,7 @@ eventd_nd_style_get_template_title(EventdNdStyle *self)
     return eventd_nd_style_get_template_title(self->parent);
 }
 
-FormatString *
+LibeventdFormatString *
 eventd_nd_style_get_template_message(EventdNdStyle *self)
 {
     if ( self->template.set )
@@ -482,7 +482,7 @@ eventd_nd_style_get_template_message(EventdNdStyle *self)
     return eventd_nd_style_get_template_message(self->parent);
 }
 
-Filename *
+LibeventdFilename *
 eventd_nd_style_get_template_image(EventdNdStyle *self)
 {
     if ( self->template.set )
@@ -490,7 +490,7 @@ eventd_nd_style_get_template_image(EventdNdStyle *self)
     return eventd_nd_style_get_template_image(self->parent);
 }
 
-Filename *
+LibeventdFilename *
 eventd_nd_style_get_template_icon(EventdNdStyle *self)
 {
     if ( self->template.set )
@@ -530,7 +530,7 @@ eventd_nd_style_get_bubble_radius(EventdNdStyle *self)
     return eventd_nd_style_get_bubble_radius(self->parent);
 }
 
-Colour
+LibeventdColour
 eventd_nd_style_get_bubble_colour(EventdNdStyle *self)
 {
     if ( self->bubble.set )
@@ -554,7 +554,7 @@ eventd_nd_style_get_title_align(EventdNdStyle *self)
     return eventd_nd_style_get_title_align(self->parent);
 }
 
-Colour
+LibeventdColour
 eventd_nd_style_get_title_colour(EventdNdStyle *self)
 {
     if ( self->title.set )
@@ -594,7 +594,7 @@ eventd_nd_style_get_message_align(EventdNdStyle *self)
     return eventd_nd_style_get_message_align(self->parent);
 }
 
-Colour
+LibeventdColour
 eventd_nd_style_get_message_colour(EventdNdStyle *self)
 {
     if ( self->message.set )
@@ -779,8 +779,8 @@ eventd_nd_notification_contents_new(EventdNdStyle *style, EventdEvent *event, gi
 {
     EventdNdNotificationContents *self;
 
-    const FormatString *title = eventd_nd_style_get_template_title(style);
-    const FormatString *message = eventd_nd_style_get_template_message(style);
+    const LibeventdFormatString *title = eventd_nd_style_get_template_title(style);
+    const LibeventdFormatString *message = eventd_nd_style_get_template_message(style);
 
     self = g_new0(EventdNdNotificationContents, 1);
 
@@ -792,8 +792,8 @@ eventd_nd_notification_contents_new(EventdNdStyle *style, EventdEvent *event, gi
         self->message = (g_free(self->message), NULL);
 
 #ifdef ENABLE_GDK_PIXBUF
-    const Filename *image = eventd_nd_style_get_template_image(style);
-    const Filename *icon = eventd_nd_style_get_template_icon(style);
+    const LibeventdFilename *image = eventd_nd_style_get_template_image(style);
+    const LibeventdFilename *icon = eventd_nd_style_get_template_icon(style);
     gchar *path;
     const gchar *data;
 

--- a/plugins/nd/src/style.h
+++ b/plugins/nd/src/style.h
@@ -49,27 +49,27 @@ void eventd_nd_style_free(gpointer style);
 
 void eventd_nd_style_update(EventdNdStyle *style, GKeyFile *config_file, gint *max_width, gint *max_height);
 
-FormatString *eventd_nd_style_get_template_title(EventdNdStyle *style);
-FormatString *eventd_nd_style_get_template_message(EventdNdStyle *style);
-Filename *eventd_nd_style_get_template_image(EventdNdStyle *style);
-Filename *eventd_nd_style_get_template_icon(EventdNdStyle *style);
+LibeventdFormatString *eventd_nd_style_get_template_title(EventdNdStyle *style);
+LibeventdFormatString *eventd_nd_style_get_template_message(EventdNdStyle *style);
+LibeventdFilename *eventd_nd_style_get_template_image(EventdNdStyle *style);
+LibeventdFilename *eventd_nd_style_get_template_icon(EventdNdStyle *style);
 
 gint eventd_nd_style_get_bubble_min_width(EventdNdStyle *style);
 gint eventd_nd_style_get_bubble_max_width(EventdNdStyle *style);
 
 gint eventd_nd_style_get_bubble_padding(EventdNdStyle *style);
 gint eventd_nd_style_get_bubble_radius(EventdNdStyle *style);
-Colour eventd_nd_style_get_bubble_colour(EventdNdStyle *style);
+LibeventdColour eventd_nd_style_get_bubble_colour(EventdNdStyle *style);
 
 const PangoFontDescription *eventd_nd_style_get_title_font(EventdNdStyle *style);
 PangoAlignment eventd_nd_style_get_title_align(EventdNdStyle *style);
-Colour eventd_nd_style_get_title_colour(EventdNdStyle *style);
+LibeventdColour eventd_nd_style_get_title_colour(EventdNdStyle *style);
 
 gint eventd_nd_style_get_message_spacing(EventdNdStyle *style);
 guint8 eventd_nd_style_get_message_max_lines(EventdNdStyle *style);
 const PangoFontDescription *eventd_nd_style_get_message_font(EventdNdStyle *style);
 PangoAlignment eventd_nd_style_get_message_align(EventdNdStyle *style);
-Colour eventd_nd_style_get_message_colour(EventdNdStyle *style);
+LibeventdColour eventd_nd_style_get_message_colour(EventdNdStyle *style);
 
 gint eventd_nd_style_get_image_max_width(EventdNdStyle *style);
 gint eventd_nd_style_get_image_max_height(EventdNdStyle *style);

--- a/plugins/notify/src/image.c
+++ b/plugins/notify/src/image.c
@@ -83,7 +83,7 @@ fail:
 }
 
 GdkPixbuf *
-eventd_libnotify_get_image(EventdEvent *event, const Filename *image_name, const Filename *icon_name, gdouble overlay_scale, gchar **icon_uri)
+eventd_libnotify_get_image(EventdEvent *event, const LibeventdFilename *image_name, const LibeventdFilename *icon_name, gdouble overlay_scale, gchar **icon_uri)
 {
     gchar *file;
     const gchar *data;

--- a/plugins/notify/src/image.h
+++ b/plugins/notify/src/image.h
@@ -23,6 +23,6 @@
 #ifndef __EVENTD_LIBNOTIFY_ICON_H__
 #define __EVENTD_LIBNOTIFY_ICON_H__
 
-GdkPixbuf *eventd_libnotify_get_image(EventdEvent *event, const Filename *event_icon, const Filename *event_overlay_icon, gdouble overlay_scale, gchar **icon_uri);
+GdkPixbuf *eventd_libnotify_get_image(EventdEvent *event, const LibeventdFilename *event_icon, const LibeventdFilename *event_overlay_icon, gdouble overlay_scale, gchar **icon_uri);
 
 #endif /* __EVENTD_LIBNOTIFY_ICON_H__ */

--- a/plugins/notify/src/notify.c
+++ b/plugins/notify/src/notify.c
@@ -42,10 +42,10 @@ struct _EventdPluginContext {
 };
 
 typedef struct {
-    FormatString *title;
-    FormatString *message;
-    Filename *image;
-    Filename *icon;
+    LibeventdFormatString *title;
+    LibeventdFormatString *message;
+    LibeventdFilename *image;
+    LibeventdFilename *icon;
     gdouble scale;
 } EventdLibnotifyEvent;
 
@@ -55,7 +55,7 @@ typedef struct {
  */
 
 static EventdLibnotifyEvent *
-_eventd_libnotify_event_new(FormatString *title, FormatString *message, Filename *image, Filename *icon, gint64 scale)
+_eventd_libnotify_event_new(LibeventdFormatString *title, LibeventdFormatString *message, LibeventdFilename *image, LibeventdFilename *icon, gint64 scale)
 {
     EventdLibnotifyEvent *event;
 
@@ -141,10 +141,10 @@ _eventd_libnotify_event_parse(EventdPluginContext *context, const gchar *id, GKe
 {
     gboolean disable;
     EventdLibnotifyEvent *libnotify_event = NULL;
-    FormatString *title = NULL;
-    FormatString *message = NULL;
-    Filename *image = NULL;
-    Filename *icon = NULL;
+    LibeventdFormatString *title = NULL;
+    LibeventdFormatString *message = NULL;
+    LibeventdFilename *image = NULL;
+    LibeventdFilename *icon = NULL;
     gint64 scale;
 
     if ( ! g_key_file_has_group(config_file, "Libnotify") )

--- a/plugins/sound/src/sound.c
+++ b/plugins/sound/src/sound.c
@@ -165,7 +165,7 @@ static void
 _eventd_sound_event_parse(EventdPluginContext *context, const gchar *id, GKeyFile *config_file)
 {
     gboolean disable;
-    Filename *sound = NULL;
+    LibeventdFilename *sound = NULL;
 
     if ( ! g_key_file_has_group(config_file, "Sound") )
         return;
@@ -196,7 +196,7 @@ _eventd_sound_config_reset(EventdPluginContext *context)
 static void
 _eventd_sound_event_action(EventdPluginContext *context, const gchar *config_id, EventdEvent *event)
 {
-    Filename *sound;
+    LibeventdFilename *sound;
     gchar *file;
     gpointer data = NULL;
     gsize length = 0;

--- a/plugins/tts/src/tts.c
+++ b/plugins/tts/src/tts.c
@@ -99,7 +99,7 @@ static void
 _eventd_tts_event_parse(EventdPluginContext *context, const gchar *id, GKeyFile *config_file)
 {
     gboolean disable;
-    FormatString *message = NULL;
+    LibeventdFormatString *message = NULL;
 
     if ( ! g_key_file_has_group(config_file, "TTS") )
         return;
@@ -130,7 +130,7 @@ _eventd_tts_config_reset(EventdPluginContext *context)
 static void
 _eventd_tts_event_action(EventdPluginContext *context, const gchar *config_id, EventdEvent *event)
 {
-    const FormatString *message;
+    const LibeventdFormatString *message;
     gchar *msg;
     espeak_ERROR error;
 

--- a/server/eventd/src/config.c
+++ b/server/eventd/src/config.c
@@ -218,7 +218,7 @@ _eventd_config_defaults(EventdConfig *config)
 static void
 _eventd_config_parse_global(EventdConfig *config, GKeyFile *config_file)
 {
-    Int integer;
+    LibeventdInt integer;
 
     if ( ! g_key_file_has_group(config_file, "Event") )
         return;
@@ -235,7 +235,7 @@ _eventd_config_parse_client(EventdConfig *config, const gchar *id, GKeyFile *con
 {
     EventdConfigEvent *event;
     gboolean disable;
-    Int timeout;
+    LibeventdInt timeout;
 
     if ( ( libeventd_config_key_file_get_boolean(config_file, "Event", "Disable", &disable) == 0 ) && disable )
     {

--- a/server/libeventd/include/libeventd-config.h
+++ b/server/libeventd/include/libeventd-config.h
@@ -25,51 +25,51 @@
 
 #include <libeventd-event-types.h>
 
-typedef struct _NkTokenList FormatString;
-typedef const gchar *(*FormatStringReplaceCallback)(const gchar *name, const EventdEvent *event, gconstpointer user_data);
+typedef struct _NkTokenList LibeventdFormatString;
+typedef const gchar *(*LibeventdFormatStringReplaceCallback)(const gchar *name, const EventdEvent *event, gconstpointer user_data);
 
 typedef struct {
     gint64 value;
     gboolean set;
-} Int;
+} LibeventdInt;
 
 typedef struct {
     gdouble r;
     gdouble g;
     gdouble b;
     gdouble a;
-} Colour;
+} LibeventdColour;
 
-typedef struct _Filename Filename;
+typedef struct _Filename LibeventdFilename;
 
 gint8 libeventd_config_key_file_get_boolean(GKeyFile *config_file, const gchar *group, const gchar *key, gboolean *value);
 gint8 libeventd_config_key_file_get_string(GKeyFile *config_file, const gchar *group, const gchar *key, gchar **value);
 gint8 libeventd_config_key_file_get_string_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *default_value, gchar **value);
 gint8 libeventd_config_key_file_get_locale_string(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, gchar **value);
 gint8 libeventd_config_key_file_get_locale_string_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, const gchar *default_value, gchar **value);
-gint8 libeventd_config_key_file_get_int(GKeyFile *config_file, const gchar *group, const gchar *key, Int *value);
+gint8 libeventd_config_key_file_get_int(GKeyFile *config_file, const gchar *group, const gchar *key, LibeventdInt *value);
 gint8 libeventd_config_key_file_get_int_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, gint64 default_value, gint64 *value);
 gint8 libeventd_config_key_file_get_enum(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar * const *values, guint64 size, guint64 *value);
 gint8 libeventd_config_key_file_get_string_list(GKeyFile *config_file, const gchar *group, const gchar *key, gchar ***value, gsize *length);
-gint8 libeventd_config_key_file_get_format_string(GKeyFile *config_file, const gchar *group, const gchar *key, FormatString **value);
-gint8 libeventd_config_key_file_get_format_string_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *default_value, FormatString **value);
-gint8 libeventd_config_key_file_get_locale_format_string(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, FormatString **value);
-gint8 libeventd_config_key_file_get_locale_format_string_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, const gchar *default_value, FormatString **value);
-gint8 libeventd_config_key_file_get_filename(GKeyFile *config_file, const gchar *group, const gchar *key, Filename **value);
-gint8 libeventd_config_key_file_get_filename_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *default_value, Filename **value);
-gint8 libeventd_config_key_file_get_locale_filename(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, Filename **value);
-gint8 libeventd_config_key_file_get_locale_filename_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, const gchar *default_value, Filename **value);
-gint8 libeventd_config_key_file_get_colour(GKeyFile *config_file, const gchar *group, const gchar *key, Colour *value);
+gint8 libeventd_config_key_file_get_format_string(GKeyFile *config_file, const gchar *group, const gchar *key, LibeventdFormatString **value);
+gint8 libeventd_config_key_file_get_format_string_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *default_value, LibeventdFormatString **value);
+gint8 libeventd_config_key_file_get_locale_format_string(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, LibeventdFormatString **value);
+gint8 libeventd_config_key_file_get_locale_format_string_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, const gchar *default_value, LibeventdFormatString **value);
+gint8 libeventd_config_key_file_get_filename(GKeyFile *config_file, const gchar *group, const gchar *key, LibeventdFilename **value);
+gint8 libeventd_config_key_file_get_filename_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *default_value, LibeventdFilename **value);
+gint8 libeventd_config_key_file_get_locale_filename(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, LibeventdFilename **value);
+gint8 libeventd_config_key_file_get_locale_filename_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, const gchar *default_value, LibeventdFilename **value);
+gint8 libeventd_config_key_file_get_colour(GKeyFile *config_file, const gchar *group, const gchar *key, LibeventdColour *value);
 
-gchar *libeventd_format_string_get_string(const FormatString *format_string, EventdEvent *event, FormatStringReplaceCallback callback, gconstpointer user_data);
-gboolean libeventd_filename_get_path(const Filename *filename, EventdEvent *event, const gchar *subdir, const gchar **data, gchar **path);
+gchar *libeventd_format_string_get_string(const LibeventdFormatString *format_string, EventdEvent *event, LibeventdFormatStringReplaceCallback callback, gconstpointer user_data);
+gboolean libeventd_filename_get_path(const LibeventdFilename *filename, EventdEvent *event, const gchar *subdir, const gchar **data, gchar **path);
 
-FormatString *libeventd_format_string_new(gchar *string);
-FormatString *libeventd_format_string_ref(FormatString *format_string);
-void libeventd_format_string_unref(FormatString *format_string);
+LibeventdFormatString *libeventd_format_string_new(gchar *string);
+LibeventdFormatString *libeventd_format_string_ref(LibeventdFormatString *format_string);
+void libeventd_format_string_unref(LibeventdFormatString *format_string);
 
-Filename *libeventd_filename_new(gchar *string);
-Filename *libeventd_filename_ref(Filename *filename);
-void libeventd_filename_unref(Filename *filename);
+LibeventdFilename *libeventd_filename_new(gchar *string);
+LibeventdFilename *libeventd_filename_ref(LibeventdFilename *filename);
+void libeventd_filename_unref(LibeventdFilename *filename);
 
 #endif /* __LIBEVENTD_CONFIG_H__ */

--- a/server/libeventd/src/config.c
+++ b/server/libeventd/src/config.c
@@ -42,19 +42,19 @@
 struct _Filename {
     guint64 ref_count;
     gchar *data_name;
-    FormatString *file_uri;
+    LibeventdFormatString *file_uri;
 };
 
 EVENTD_EXPORT
-FormatString *
+LibeventdFormatString *
 libeventd_format_string_new(gchar *string)
 {
     return nk_token_list_parse(string);
 }
 
 EVENTD_EXPORT
-FormatString *
-libeventd_format_string_ref(FormatString *format_string)
+LibeventdFormatString *
+libeventd_format_string_ref(LibeventdFormatString *format_string)
 {
     if ( format_string == NULL )
         return NULL;
@@ -63,7 +63,7 @@ libeventd_format_string_ref(FormatString *format_string)
 
 EVENTD_EXPORT
 void
-libeventd_format_string_unref(FormatString *format_string)
+libeventd_format_string_unref(LibeventdFormatString *format_string)
 {
     if ( format_string == NULL )
         return;
@@ -71,11 +71,11 @@ libeventd_format_string_unref(FormatString *format_string)
 }
 
 EVENTD_EXPORT
-Filename *
+LibeventdFilename *
 libeventd_filename_new(gchar *string)
 {
     gchar *data_name = NULL;
-    FormatString *file_uri = NULL;
+    LibeventdFormatString *file_uri = NULL;
 
     if ( g_str_has_prefix(string, "file://") )
         file_uri = libeventd_format_string_new(string);
@@ -86,9 +86,9 @@ libeventd_filename_new(gchar *string)
         g_free(string);
         return NULL;
     }
-    Filename *filename;
+    LibeventdFilename *filename;
 
-    filename = g_new0(Filename, 1);
+    filename = g_new0(LibeventdFilename, 1);
     filename->ref_count = 1;
 
     filename->data_name = data_name;
@@ -98,8 +98,8 @@ libeventd_filename_new(gchar *string)
 }
 
 EVENTD_EXPORT
-Filename *
-libeventd_filename_ref(Filename *filename)
+LibeventdFilename *
+libeventd_filename_ref(LibeventdFilename *filename)
 {
     if ( filename != NULL )
         ++filename->ref_count;
@@ -108,7 +108,7 @@ libeventd_filename_ref(Filename *filename)
 
 EVENTD_EXPORT
 void
-libeventd_filename_unref(Filename *filename)
+libeventd_filename_unref(LibeventdFilename *filename)
 {
     if ( filename == NULL )
         return;
@@ -154,7 +154,7 @@ libeventd_config_key_file_get_boolean(GKeyFile *config_file, const gchar *group,
 
 EVENTD_EXPORT
 gint8
-libeventd_config_key_file_get_int(GKeyFile *config_file, const gchar *group, const gchar *key, Int *value)
+libeventd_config_key_file_get_int(GKeyFile *config_file, const gchar *group, const gchar *key, LibeventdInt *value)
 {
     GError *error = NULL;
 
@@ -169,7 +169,7 @@ gint8
 libeventd_config_key_file_get_int_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, gint64 default_value, gint64 *ret_value)
 {
     gint8 r;
-    Int value;
+    LibeventdInt value;
 
     r = libeventd_config_key_file_get_int(config_file, group, key, &value);
     if ( r >= 0 )
@@ -257,7 +257,7 @@ libeventd_config_key_file_get_string_list(GKeyFile *config_file, const gchar *gr
 }
 
 static gint8
-_libeventd_config_key_file_get_format_string(gchar *string, FormatString **format_string)
+_libeventd_config_key_file_get_format_string(gchar *string, LibeventdFormatString **format_string)
 {
     libeventd_format_string_unref(*format_string);
     *format_string = libeventd_format_string_new(string);
@@ -267,7 +267,7 @@ _libeventd_config_key_file_get_format_string(gchar *string, FormatString **forma
 
 EVENTD_EXPORT
 gint8
-libeventd_config_key_file_get_format_string(GKeyFile *config_file, const gchar *group, const gchar *key, FormatString **value)
+libeventd_config_key_file_get_format_string(GKeyFile *config_file, const gchar *group, const gchar *key, LibeventdFormatString **value)
 {
     gchar *string;
     gint8 r;
@@ -280,7 +280,7 @@ libeventd_config_key_file_get_format_string(GKeyFile *config_file, const gchar *
 
 EVENTD_EXPORT
 gint8
-libeventd_config_key_file_get_format_string_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *default_value, FormatString **value)
+libeventd_config_key_file_get_format_string_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *default_value, LibeventdFormatString **value)
 {
     gchar *string;
     gint8 r;
@@ -293,7 +293,7 @@ libeventd_config_key_file_get_format_string_with_default(GKeyFile *config_file, 
 
 EVENTD_EXPORT
 gint8
-libeventd_config_key_file_get_locale_format_string(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, FormatString **value)
+libeventd_config_key_file_get_locale_format_string(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, LibeventdFormatString **value)
 {
     gchar *string;
     gint8 r;
@@ -306,7 +306,7 @@ libeventd_config_key_file_get_locale_format_string(GKeyFile *config_file, const 
 
 EVENTD_EXPORT
 gint8
-libeventd_config_key_file_get_locale_format_string_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, const gchar *default_value, FormatString **value)
+libeventd_config_key_file_get_locale_format_string_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, const gchar *default_value, LibeventdFormatString **value)
 {
     gchar *string;
     gint8 r;
@@ -318,9 +318,9 @@ libeventd_config_key_file_get_locale_format_string_with_default(GKeyFile *config
 }
 
 static gint8
-_libeventd_config_key_file_get_filename(gchar *string, Filename **value)
+_libeventd_config_key_file_get_filename(gchar *string, LibeventdFilename **value)
 {
-    Filename *filename;
+    LibeventdFilename *filename;
 
     filename = libeventd_filename_new(string);
     if ( filename == NULL )
@@ -334,7 +334,7 @@ _libeventd_config_key_file_get_filename(gchar *string, Filename **value)
 
 EVENTD_EXPORT
 gint8
-libeventd_config_key_file_get_filename(GKeyFile *config_file, const gchar *group, const gchar *key, Filename **value)
+libeventd_config_key_file_get_filename(GKeyFile *config_file, const gchar *group, const gchar *key, LibeventdFilename **value)
 {
     gchar *string;
     gint8 r;
@@ -347,7 +347,7 @@ libeventd_config_key_file_get_filename(GKeyFile *config_file, const gchar *group
 
 EVENTD_EXPORT
 gint8
-libeventd_config_key_file_get_filename_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *default_value, Filename **value)
+libeventd_config_key_file_get_filename_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *default_value, LibeventdFilename **value)
 {
     gchar *string;
     gint8 r;
@@ -360,7 +360,7 @@ libeventd_config_key_file_get_filename_with_default(GKeyFile *config_file, const
 
 EVENTD_EXPORT
 gint8
-libeventd_config_key_file_get_locale_filename(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, Filename **value)
+libeventd_config_key_file_get_locale_filename(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, LibeventdFilename **value)
 {
     gchar *string;
     gint8 r;
@@ -373,7 +373,7 @@ libeventd_config_key_file_get_locale_filename(GKeyFile *config_file, const gchar
 
 EVENTD_EXPORT
 gint8
-libeventd_config_key_file_get_locale_filename_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, const gchar *default_value, Filename **value)
+libeventd_config_key_file_get_locale_filename_with_default(GKeyFile *config_file, const gchar *group, const gchar *key, const gchar *locale, const gchar *default_value, LibeventdFilename **value)
 {
     gchar *string;
     gint8 r;
@@ -386,7 +386,7 @@ libeventd_config_key_file_get_locale_filename_with_default(GKeyFile *config_file
 
 EVENTD_EXPORT
 gint8
-libeventd_config_key_file_get_colour(GKeyFile *config_file, const gchar *section, const gchar *key, Colour *colour)
+libeventd_config_key_file_get_colour(GKeyFile *config_file, const gchar *section, const gchar *key, LibeventdColour *colour)
 {
     gchar *string;
     gint8 r;
@@ -414,7 +414,7 @@ libeventd_config_key_file_get_colour(GKeyFile *config_file, const gchar *section
 
 typedef struct {
     EventdEvent *event;
-    FormatStringReplaceCallback callback;
+    LibeventdFormatStringReplaceCallback callback;
     gconstpointer user_data;
 } FormatStringReplaceData;
 
@@ -431,7 +431,7 @@ _libeventd_token_list_callback(const gchar *token, guint64 value, gconstpointer 
 
 EVENTD_EXPORT
 gchar *
-libeventd_format_string_get_string(const FormatString *format_string, EventdEvent *event, FormatStringReplaceCallback callback, gconstpointer user_data)
+libeventd_format_string_get_string(const LibeventdFormatString *format_string, EventdEvent *event, LibeventdFormatStringReplaceCallback callback, gconstpointer user_data)
 {
     if ( format_string == NULL )
         return NULL;
@@ -447,7 +447,7 @@ libeventd_format_string_get_string(const FormatString *format_string, EventdEven
 
 EVENTD_EXPORT
 gboolean
-libeventd_filename_get_path(const Filename *filename, EventdEvent *event, const gchar *subdir, const gchar **ret_data, gchar **ret_path)
+libeventd_filename_get_path(const LibeventdFilename *filename, EventdEvent *event, const gchar *subdir, const gchar **ret_data, gchar **ret_path)
 {
     g_return_val_if_fail(filename != NULL, FALSE);
     g_return_val_if_fail(event != NULL, FALSE);


### PR DESCRIPTION
The types are very generically named which is just asking for symbol
collisions (particularly thinking of C++ here where the types are
mangled into the symbol name). GObject's introspection also wants
uniform prefixes.

Signed-off-by: Ben Boeckel <mathstuf@gmail.com>