### PR TITLE
notify: allow custom timeouts

### DIFF
--- a/plugins/notify/man/eventd-notify.conf.xml
+++ b/plugins/notify/man/eventd-notify.conf.xml
@@ -111,6 +111,14 @@
                 </varlistentry>
 
                 <varlistentry>
+                    <term><varname>Timeout=</varname> (defaults to <literal>-1</literal>)</term>
+                    <listitem>
+                        <para>An <type>integer</type></para>
+                        <para>The length of time the notification should be displayed. If -1, use the event's timeout or the top-level timeout. Time is in milliseconds.</para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
                     <term><varname>Urgency=</varname> (defaults to <literal>normal</literal>)</term>
                     <listitem>
                         <para>An <type>enumeration</type></para>


### PR DESCRIPTION
Not all event sources necessarily allow setting this. Instead of
requiring sources to get it right, allow notifications to be up for a
configurable amount of time.

Signed-off-by: Ben Boeckel <mathstuf@gmail.com>