### PR TITLE
plugins/nd: Fix building with CFLAGS=-fno-common

### DIFF
--- a/plugins/nd/src/backend.h
+++ b/plugins/nd/src/backend.h
@@ -37,7 +37,7 @@ typedef enum {
     _EVENTD_ND_BACKENDS_SIZE
 } EventdNdBackends;
 
-const gchar *eventd_nd_backends_names[_EVENTD_ND_BACKENDS_SIZE];
+extern const gchar *eventd_nd_backends_names[_EVENTD_ND_BACKENDS_SIZE];
 
 typedef struct {
     EventdNdContext *context;


### PR DESCRIPTION
With the GCC -fno-common flag, enabled by default in GCC >=10, the
linker fails with messages like these:

ld: plugins/nd/1b87e75@@nd@sha/src_notification.c.o:(.bss+0x0): multiple
definition of `eventd_nd_backends_names';
plugins/nd/1b87e75@@nd@sha/src_nd.c.o:(.data.rel.local+0x20): first
defined here
ld: plugins/nd/1b87e75@@nd@sha/src_backends.c.o:(.bss+0x0): multiple
definition of `eventd_nd_backends_names';
plugins/nd/1b87e75@@nd@sha/src_nd.c.o:(.data.rel.local+0x20): first
defined here
collect2: error: ld returned 1 exit status

Fix this by declaring eventd_nd_backends_names as extern.

Signed-off-by: Jeroen Roovers <jer@gentoo.org>